### PR TITLE
Hygiene: no exits, prints or hidden state

### DIFF
--- a/tests/whr_test.py
+++ b/tests/whr_test.py
@@ -2,6 +2,7 @@ import copy
 import sys
 import os
 import pickle
+import warnings
 import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
@@ -10,7 +11,7 @@ from whr import utils
 
 
 def setup_game_with_elo(white_elo, black_elo, handicap):
-    whr = whole_history_rating.Base()
+    whr = whole_history_rating.WHR()
     game = whr.create_game("black", "white", "W", 1, handicap)
     game.black_player.days[0].elo = black_elo
     game.white_player.days[0].elo = white_elo
@@ -58,7 +59,7 @@ def test_winrates_should_be_inversely_proportional_with_handicap():
 
 
 def test_output():
-    whr = whole_history_rating.Base()
+    whr = whole_history_rating.WHR()
     whr.create_game("shusaku", "shusai", "B", 1, 0)
     whr.create_game("shusaku", "shusai", "W", 2, 0)
     whr.create_game("shusaku", "shusai", "W", 3, 0)
@@ -76,7 +77,7 @@ def test_output():
 
 
 def test_output2():
-    whr = whole_history_rating.Base()
+    whr = whole_history_rating.WHR()
     whr.create_game("shusaku", "shusai", "B", 1, 0)
     whr.create_game("shusaku", "shusai", "W", 2, 0)
     whr.create_game("shusaku", "shusai", "W", 3, 0)
@@ -98,7 +99,7 @@ def test_output2():
 
 
 def test_unstable_exception_raised_in_certain_cases():
-    whr = whole_history_rating.Base()
+    whr = whole_history_rating.WHR()
     for _ in range(10):
         whr.create_game("anchor", "player", "B", 1, 0)
         whr.create_game("anchor", "player", "W", 1, 0)
@@ -110,7 +111,7 @@ def test_unstable_exception_raised_in_certain_cases():
 
 
 def test_log_likelihood():
-    whr = whole_history_rating.Base()
+    whr = whole_history_rating.WHR()
     whr.create_game("shusaku", "shusai", "B", 1, 0)
     whr.create_game("shusaku", "shusai", "W", 4, 0)
     whr.create_game("shusaku", "shusai", "W", 10, 0)
@@ -126,7 +127,7 @@ def test_log_likelihood():
 
 def test_creating_games():
     # test creating the base with modified w2 and uncased
-    whr = whole_history_rating.Base(config={"w2": 14, "uncased": True})
+    whr = whole_history_rating.WHR(config={"w2": 14, "uncased": True})
     # test creating one game
     assert isinstance(
         whr.create_game("shusaku", "shusai", "B", 4, 0), whole_history_rating.Game
@@ -143,7 +144,7 @@ def test_creating_games():
 
 
 def test_loading_several_games_at_once(capsys):
-    whr = whole_history_rating.Base()
+    whr = whole_history_rating.WHR()
     # test loading several games at once
     test_games = [
         "shusaku; shusai; B; 1",
@@ -163,14 +164,15 @@ def test_loading_several_games_at_once(capsys):
     ]
     # test getting ratings for player shusai, only current elo and uncertainty
     assert whr.ratings_for_player("shusai", current=True) == (87.0, 0.84)
-    # test getting probability of future match between shusaku and nobody2 (which default to 1 win 1 loss)
+    # test getting probability of future match between shusai and nobody2 (an
+    # unknown player, treated as an even gamma=1 reference); it is a pure query
+    # that neither prints nor persists nobody2.
     assert whr.probability_future_match("shusai", "nobody2", 0) == (
         0.6224906898220315,
         0.3775093101779684,
     )
-    display = "win probability: shusai:62.25%; nobody2:37.75%\n"
-    captured = capsys.readouterr()
-    assert display == captured.out
+    assert capsys.readouterr().out == ""
+    assert "nobody2" not in whr.players
     # test getting log likelihood of base
     assert whr.log_likelihood() == 0.7431542354571272
     # test printing ordered ratings
@@ -196,9 +198,9 @@ def test_loading_several_games_at_once(capsys):
         86.88207745833284,
     ]
     # test saving base
-    whole_history_rating.Base.save_base(whr, "test_whr.pkl")
+    whole_history_rating.WHR.save_base(whr, "test_whr.pkl")
     # test loading base
-    whr2 = whole_history_rating.Base.load_base("test_whr.pkl")
+    whr2 = whole_history_rating.WHR.load_base("test_whr.pkl")
     # test inspecting the first game
     whr_games = [str(x) for x in whr.games]
     whr2_games = [str(x) for x in whr2.games]
@@ -206,11 +208,11 @@ def test_loading_several_games_at_once(capsys):
 
 
 def test_save_and_load():
-    whr = whole_history_rating.Base(
+    whr = whole_history_rating.WHR(
         config={"w2": 1000, "uncased": True, "debug": True, "extra_parameter": "hello"}
     )
-    whole_history_rating.Base.save_base(whr, "test_whr.pkl")
-    whr2 = whole_history_rating.Base.load_base("test_whr.pkl")
+    whole_history_rating.WHR.save_base(whr, "test_whr.pkl")
+    whr2 = whole_history_rating.WHR.load_base("test_whr.pkl")
     assert whr.config == whr2.config
 
 
@@ -218,14 +220,14 @@ def test_save_and_load_large_history_does_not_hit_recursion_limit(tmp_path):
     # A large, densely connected history produces a deep object graph.
     # Pickling that graph directly overflows the (C) stack (see issue #12),
     # so serialization must not rely on recursively walking it.
-    whr = whole_history_rating.Base()
+    whr = whole_history_rating.WHR()
     for i in range(2000):
         whr.create_game(f"p{i}", f"p{i+1}", "B", i + 1, 0)
     whr.iterate(10)
 
     path = str(tmp_path / "large.pkl")
     whr.save_base(path)
-    whr2 = whole_history_rating.Base.load_base(path)
+    whr2 = whole_history_rating.WHR.load_base(path)
 
     # Computed ratings must survive the round-trip so the history does not
     # have to be re-rated from scratch after loading.
@@ -234,18 +236,18 @@ def test_save_and_load_large_history_does_not_hit_recursion_limit(tmp_path):
 
 
 def test_save_and_load_preserves_players_without_games(tmp_path):
-    # Querying a future match (or ratings) creates a player that has no games
-    # and therefore no rated days. Such players must survive save/load instead
+    # A player can exist without any game (e.g. created via player_by_name) and
+    # therefore without a rated day. Such players must survive save/load instead
     # of making load_base raise a KeyError.
-    whr = whole_history_rating.Base()
+    whr = whole_history_rating.WHR()
     whr.load_games(["a b B 1"])
     whr.iterate(5)
-    whr.probability_future_match("a", "ghost")
+    whr.player_by_name("ghost")
     assert "ghost" in whr.players
 
     path = str(tmp_path / "ghost.pkl")
     whr.save_base(path)
-    loaded = whole_history_rating.Base.load_base(path)
+    loaded = whole_history_rating.WHR.load_base(path)
 
     assert "ghost" in loaded.players
     assert loaded.get_ordered_ratings() == whr.get_ordered_ratings()
@@ -255,7 +257,7 @@ def test_ratings_are_plain_python_floats():
     # After the multidimensional Newton update the ratings would otherwise be
     # numpy scalars, which render as "np.float64(...)" under numpy 2.x and leak
     # into printed/returned ratings.
-    whr = whole_history_rating.Base()
+    whr = whole_history_rating.WHR()
     whr.load_games(["a b B 1", "a b W 2", "a c B 3"])
     whr.iterate(10)
 
@@ -269,7 +271,7 @@ def test_ratings_are_plain_python_floats():
 def test_load_base_reads_legacy_format(tmp_path):
     # Files written by previous versions pickled the object graph as a plain
     # list [players, games, config]. load_base must still read them.
-    whr = whole_history_rating.Base()
+    whr = whole_history_rating.WHR()
     whr.load_games(["a b B 1", "a b W 2", "a c B 3"])
     whr.iterate(10)
 
@@ -277,13 +279,13 @@ def test_load_base_reads_legacy_format(tmp_path):
     with open(path, "wb") as f:
         pickle.dump([whr.players, whr.games, whr.config], f)
 
-    loaded = whole_history_rating.Base.load_base(path)
+    loaded = whole_history_rating.WHR.load_base(path)
     assert loaded.get_ordered_ratings() == whr.get_ordered_ratings()
     assert [str(g) for g in loaded.games] == [str(g) for g in whr.games]
 
 
 def test_auto_iterate(capsys):
-    whr = whole_history_rating.Base()
+    whr = whole_history_rating.WHR()
     # test loading several games at once
     test_games = [
         "shusaku; shusai; B; 1",
@@ -313,3 +315,59 @@ def test_auto_iterate(capsys):
     iterations5, is_stable5 = whr5.auto_iterate(time_limit=1, batch_size=1)
     assert iterations5 == 12
     assert is_stable5
+
+
+def test_whr_is_the_public_name_and_base_is_deprecated():
+    # WHR is the canonical name and must not warn.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        whr = whole_history_rating.WHR()
+    assert isinstance(whr, whole_history_rating.WHR)
+    # Base still works but is deprecated.
+    with pytest.warns(DeprecationWarning):
+        legacy = whole_history_rating.Base()
+    assert isinstance(legacy, whole_history_rating.WHR)
+
+
+def test_config_is_not_mutated_or_shared():
+    cfg = {"w2": 14}
+    a = whole_history_rating.WHR(cfg)
+    assert cfg == {"w2": 14}  # the caller's dict is left untouched
+    b = whole_history_rating.WHR(cfg)
+    assert a.config is not b.config  # instances do not share the same dict
+
+
+def test_probability_future_match_is_a_pure_query(capsys):
+    whr = whole_history_rating.WHR()
+    whr.create_game("a", "b", "B", 1, 0)
+    whr.iterate(10)
+    before = set(whr.players)
+
+    p1, p2 = whr.probability_future_match("a", "ghost")
+
+    assert set(whr.players) == before  # querying does not persist players
+    assert capsys.readouterr().out == ""  # and does not print
+    assert 0 <= p1 <= 1 and 0 <= p2 <= 1
+
+
+def test_ratings_for_player_unknown_raises_clear_error():
+    whr = whole_history_rating.WHR()
+    whr.create_game("a", "b", "B", 1, 0)
+    whr.iterate(5)
+    with pytest.raises(ValueError):
+        whr.ratings_for_player("unknown", current=True)
+    assert "unknown" not in whr.players  # and does not create the player
+
+
+def test_log_likelihood_raises_instead_of_exiting_on_overflow(monkeypatch):
+    whr = whole_history_rating.WHR()
+    whr.create_game("a", "b", "B", 1, 0)
+    whr.create_game("a", "b", "W", 2, 0)
+    whr.iterate(1)
+    player = whr.players["a"]
+    # Force the overflow guard that previously called sys.exit().
+    monkeypatch.setattr(
+        type(player.days[0]), "log_likelihood", lambda self: float(sys.maxsize)
+    )
+    with pytest.raises(utils.UnstableRatingException):
+        player.log_likelihood()

--- a/whr/__init__.py
+++ b/whr/__init__.py
@@ -13,7 +13,7 @@ from whr.game import Game
 from whr.player import Player
 from whr.playerday import PlayerDay
 from whr.utils import UnstableRatingException
-from whr.whole_history_rating import Base
+from whr.whole_history_rating import WHR, Base
 
 try:
     __version__ = version("whole-history-rating")
@@ -21,6 +21,7 @@ except PackageNotFoundError:  # running from a source checkout without an instal
     __version__ = "0.0.0.dev0"
 
 __all__ = [
+    "WHR",
     "Base",
     "Game",
     "Player",

--- a/whr/player.py
+++ b/whr/player.py
@@ -50,10 +50,11 @@ class Player:
                     self.days[i].log_likelihood() >= sys.maxsize
                     or math.log(prior) >= sys.maxsize
                 ):
-                    print(
-                        f"Infinity at {self.__str__()}: {self.days[i].log_likelihood()} + {math.log(prior)}: prior = {prior}, days = {self.days}"
+                    raise UnstableRatingException(
+                        f"Infinity while computing log likelihood at {self}: "
+                        f"day log likelihood = {self.days[i].log_likelihood()}, "
+                        f"log(prior) = {math.log(prior)}, prior = {prior}"
                     )
-                    sys.exit()
                 result += self.days[i].log_likelihood() + math.log(prior)
         return result
 

--- a/whr/playerday.py
+++ b/whr/playerday.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-import sys
 
 from whr import player as P
 from whr import game as G
@@ -66,11 +65,8 @@ class PlayerDay:
         if self._won_game_terms is None:
             self._won_game_terms = []
             for g in self.won_games:
+                # opponents_adjusted_gamma already raises on a non-finite gamma.
                 other_gamma = g.opponents_adjusted_gamma(self.player)
-                if other_gamma == 0 or other_gamma is None or other_gamma > sys.maxsize:
-                    print(
-                        f"other_gamma ({g.opponent(self.player).__str__()}) = {other_gamma}"
-                    )
                 self._won_game_terms.append([1.0, 0.0, 1.0, other_gamma])
             if self.is_first_day:
                 # win against virtual player ranked with gamma = 1.0
@@ -86,11 +82,8 @@ class PlayerDay:
         if self._lost_game_terms is None:
             self._lost_game_terms = []
             for g in self.lost_games:
+                # opponents_adjusted_gamma already raises on a non-finite gamma.
                 other_gamma = g.opponents_adjusted_gamma(self.player)
-                if other_gamma == 0 or other_gamma is None or other_gamma > sys.maxsize:
-                    print(
-                        f"other_gamma ({g.opponent(self.player).__str__()}) = {other_gamma}"
-                    )
                 self._lost_game_terms.append([0.0, other_gamma, 1.0, other_gamma])
             if self.is_first_day:
                 # win against virtual player ranked with gamma = 1.0

--- a/whr/whole_history_rating.py
+++ b/whr/whole_history_rating.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 import ast
 import pickle
+import warnings
 from typing import Any
 
 from whr.utils import test_stability
@@ -10,9 +11,11 @@ from whr.player import Player
 from whr.game import Game
 
 
-class Base:
+class WHR:
     def __init__(self, config: dict[str, Any] | None = None):
-        self.config = config if config is not None else {}
+        # Copy the caller's dict so we never mutate it and instances never
+        # share the same config object.
+        self.config = dict(config) if config is not None else {}
         self.config.setdefault("debug", False)
         self.config.setdefault("w2", 300.0)
         self.config.setdefault("uncased", False)
@@ -90,6 +93,12 @@ class Base:
             self.players[name] = Player(name, self.config)
         return self.players[name]
 
+    def _existing_player(self, name: str) -> Player | None:
+        """Returns the player with the given name, or None, without creating it."""
+        if self.config["uncased"]:
+            name = name.lower()
+        return self.players.get(name)
+
     def ratings_for_player(
         self, name, current: bool = False
     ) -> list[tuple[int, float, float]] | tuple[float, float]:
@@ -101,10 +110,13 @@ class Base:
 
         Returns:
             list[tuple[int, float, float]] | tuple[float, float]: For each day, includes the time step, the elo rating, and the uncertainty if current is False, else just return the elo and uncertainty of the last day
+
+        Raises:
+            ValueError: If the player is unknown or has no rated day.
         """
-        if self.config["uncased"]:
-            name = name.lower()
-        player = self.player_by_name(name)
+        player = self._existing_player(name)
+        if player is None or len(player.days) == 0:
+            raise ValueError(f"No ratings available for unknown player {name!r}")
         if current:
             return (
                 round(player.days[-1].elo),
@@ -164,7 +176,9 @@ class Base:
         game.white_player.add_game(game)
         game.black_player.add_game(game)
         if game.bpd is None:
-            print("Bad game")
+            raise RuntimeError(
+                "Game could not be attached to the black player's playing day"
+            )
         self.games.append(game)
         return game
 
@@ -219,7 +233,7 @@ class Base:
             handicap (float, optional): The handicap (in elo points).
 
         Returns:
-            tuple[float, float]: The winning probabilities for name1 and name2, respectively, as percentages rounded to the second decimal.
+            tuple[float, float]: The winning probabilities for name1 and name2 respectively. Unknown players are treated as an even (gamma = 1) reference without being added to the base.
 
         Raises:
             AttributeError: Raised if name1 and name2 are equal
@@ -230,25 +244,23 @@ class Base:
             name2 = name2.lower()
         if name1 == name2:
             raise AttributeError("Invalid game (black == white)")
-        player1 = self.player_by_name(name1)
-        player2 = self.player_by_name(name2)
+        # Pure query: look players up without creating persistent entries.
+        player1 = self._existing_player(name1)
+        player2 = self._existing_player(name2)
         bpd_gamma = 1
         bpd_elo = 0
         wpd_gamma = 1
         wpd_elo = 0
-        if len(player1.days) > 0:
+        if player1 is not None and len(player1.days) > 0:
             bpd = player1.days[-1]
             bpd_gamma = bpd.gamma()
             bpd_elo = bpd.elo
-        if len(player2.days) != 0:
+        if player2 is not None and len(player2.days) > 0:
             wpd = player2.days[-1]
             wpd_gamma = wpd.gamma()
             wpd_elo = wpd.elo
         player1_proba = bpd_gamma / (bpd_gamma + 10 ** ((wpd_elo - handicap) / 400.0))
         player2_proba = wpd_gamma / (wpd_gamma + 10 ** ((bpd_elo + handicap) / 400.0))
-        print(
-            f"win probability: {name1}:{player1_proba*100:.2f}%; {name2}:{player2_proba*100:.2f}%"
-        )
         return player1_proba, player2_proba
 
     def _run_one_iteration(self) -> None:
@@ -346,31 +358,33 @@ class Base:
                 for k, v in self.config.items()
                 if k in ["w2", "debug", "uncased"]
             }
-            print(
-                "WARNING: some elements in self.config you configured can't be pickled, only 'w2', 'debug' and 'uncased' parameters will be saved for self.config"
+            warnings.warn(
+                "Some elements in config cannot be pickled; only 'w2', 'debug' "
+                "and 'uncased' will be saved.",
+                stacklevel=2,
             )
         with open(path, "wb") as f:
             pickle.dump({"config": config, "games": games, "ratings": ratings}, f)
 
     @staticmethod
-    def load_base(path: str) -> Base:
+    def load_base(path: str) -> WHR:
         """Loads a saved base from a specified path.
 
         Args:
             path (str): The path to the saved base.
 
         Returns:
-            Base: The loaded base.
+            WHR: The loaded base.
         """
         with open(path, "rb") as f:
             data = pickle.load(f)
         if not isinstance(data, dict):
             # Legacy format: a pickled object graph as [players, games, config].
             players, games, config = data
-            result = Base()
+            result = WHR()
             result.config, result.games, result.players = config, games, players
             return result
-        result = Base(data["config"])
+        result = WHR(data["config"])
         for black, white, winner, time_step, handicap, extras in data["games"]:
             result.create_game(black, white, winner, time_step, handicap, extras)
         for name, days in data["ratings"].items():
@@ -383,3 +397,16 @@ class Base:
                 player_day.r = r
                 player_day.uncertainty = uncertainty
         return result
+
+
+class Base(WHR):
+    """Deprecated alias for :class:`WHR`, kept for backward compatibility."""
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        warnings.warn(
+            "Base has been renamed to WHR; the Base alias will be removed in a "
+            "future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(config)


### PR DESCRIPTION
Part of the code-health review (1 of 3 remaining PRs, based on `master`).

Makes the library well-behaved as a dependency.

- Rename public class `Base` → `WHR`; keep `Base` as a deprecated subclass emitting `DeprecationWarning`.
- Copy the `config` dict in `__init__` (no caller mutation, no sharing between instances).
- `probability_future_match` is now a pure query: no stdout; unknown players are an even reference and are not persisted.
- `ratings_for_player` raises a clear `ValueError` for an unknown player instead of `IndexError`.
- Replace `log_likelihood`'s `sys.exit()` with `UnstableRatingException`.
- Raise instead of printing "Bad game"; route the save warning through `warnings.warn`; drop dead diagnostic prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)