### PR TITLE
Tooling, CI, and 2.0.0 release prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Lint (ruff)
+        run: |
+          uv run ruff check whr tests
+          uv run ruff format --check whr tests
+
+      - name: Type-check (mypy)
+        run: uv run mypy
+
+      - name: Test (pytest)
+        run: uv run pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2026-07-22
+
+This is a substantial rework of the packaging and public API. It contains
+breaking changes; see the migration notes below.
+
+### Added
+
+- `WHR` is now the public class name, exported directly from the package
+  (`from whr import WHR`), along with `Game`, `Player`, `PlayerDay`,
+  `UnstableRatingException` and `__version__`.
+- A proper build backend (hatchling), package metadata (MIT license, authors,
+  classifiers, project URLs) and a `whr/__init__.py`, so `pip install` ships a
+  working package.
+- `save_base`/`load_base` now serialize a flat description (config, games and
+  computed ratings), so saving and loading works for a history of any size and
+  preserves the computed ratings on reload (#12).
+- Loading of legacy pickle files written by older versions is still supported.
+- Developer tooling: ruff (lint + format), mypy, pytest configuration, and a
+  GitHub Actions CI matrix (Python 3.11, 3.12, 3.13).
+
+### Changed
+
+- **Breaking:** the `Base` class has been renamed to `WHR`. `Base` remains as a
+  deprecated alias that emits a `DeprecationWarning`; it will be removed in a
+  future release.
+- **Breaking:** `probability_future_match` is now a pure query — it no longer
+  prints to stdout, and unknown players are treated as an even (gamma = 1)
+  reference without being added to the base.
+- **Breaking:** `ratings_for_player` raises `ValueError` for an unknown player
+  instead of silently creating it and then failing with `IndexError`.
+- **Breaking:** the save/load file format changed (old files remain readable).
+- **Breaking:** the minimum supported Python is now 3.11 and numpy `>= 2.0`.
+- Ratings (`elo`, uncertainty) are returned as plain Python floats.
+
+### Fixed
+
+- `RecursionError` when saving or loading large, densely connected histories
+  (#12).
+- The library no longer calls `sys.exit()` on a numerical overflow; it raises
+  `UnstableRatingException` instead.
+- The `config` dict passed to the constructor is no longer mutated, and two
+  instances no longer share the same config object.
+
+### Removed
+
+- The dead `Game.handicap_proc` attribute.
+- The placeholder `main.py`.
+
+## Migration from 1.x
+
+- Replace `whole_history_rating.Base(...)` with `whole_history_rating.WHR(...)`
+  (or `from whr import WHR`). `Base` still works but is deprecated.
+- `probability_future_match` no longer prints; use its return value.
+- Wrap `ratings_for_player` in a `try/except ValueError` if you may query an
+  unknown player.
+- Re-save any state you need in the new format; old files still load.

--- a/README.md
+++ b/README.md
@@ -17,13 +17,16 @@ pip install whole-history-rating
 
 ### Basic Setup
 
-Start by importing the library and initializing the base WHR object:
+Start by importing the library and initializing the WHR object:
 
 ```python
-from whr import whole_history_rating
+from whr import WHR
 
-whr = whole_history_rating.Base()
+whr = WHR()
 ```
+
+> The class used to be called `Base`. That name still works as a deprecated
+> alias (it emits a `DeprecationWarning`); prefer `WHR` in new code.
 
 ### Creating Games
 
@@ -72,19 +75,20 @@ Retrieve and view player ratings, which include the day number, elo rating, and 
 ```python
 # Example output for whr.ratings_for_player("shusaku")
 print(whr.ratings_for_player("shusaku"))
-# Output:
-#   [[1, -43, 0.84], 
-#    [2, -45, 0.84], 
-#    [3, -45, 0.84]]
+# Output (one (day, elo, uncertainty) tuple per playing day):
+#   [(1, -43, 0.84),
+#    (2, -45, 0.84),
+#    (3, -45, 0.84)]
 
 # Example output for whr.ratings_for_player("shusai")
 print(whr.ratings_for_player("shusai"))
 # Output:
-#   [[1, 43, 0.84], 
-#    [2, 45, 0.84], 
-#    [3, 45, 0.84]]
-
+#   [(1, 43, 0.84),
+#    (2, 45, 0.84),
+#    (3, 45, 0.84)]
 ```
+
+Querying an unknown player raises a `ValueError`.
 
 You can also view or retrieve all ratings in order:
 
@@ -98,12 +102,13 @@ ratings = whr.get_ordered_ratings(current=False, compact=False)  # Set `compact=
 Predict the outcome of future matches, including between non-existent players:
 
 ```python
-# Example of predicting a future match outcome
+# Example of predicting a future match outcome. It is a pure query: it does
+# not print anything, and unknown players are treated as an even (gamma = 1)
+# reference without being added to the base.
 probability = whr.probability_future_match("shusaku", "shusai", 0)
 print(f"Win probability: shusaku: {probability[0]*100}%; shusai: {probability[1]*100}%")
 # Output:
-#   Win probability: shusaku: 37.24%; shusai: 62.76%  <== this is printed
-#   (0.3724317501643667, 0.6275682498356332)
+#   Win probability: shusaku: 37.24%; shusai: 62.76%
 ```
 
 
@@ -143,19 +148,24 @@ Save the current state to a file and reload it later to avoid recalculating:
 
 ```python
 whr.save_base('path_to_save.whr')
-whr2 = whole_history_rating.Base.load_base('path_to_save.whr')
+whr2 = WHR.load_base('path_to_save.whr')
 ```
+
+The state is serialized as a flat description (config, games and computed
+ratings) rather than the raw object graph, so saving and loading works for a
+history of any size and the computed ratings are preserved on reload. Files
+written by older versions are still readable.
 
 ## Optional Configuration
 
 Adjust the `w2` parameter, which influences the variance of rating change over time, allowing for faster or slower progression. The default is set to 300, but Rémi Coulom used a value of 14 in his paper to achieve his results.
 
 ```python
-whr = whole_history_rating.Base({'w2': 14})
+whr = WHR({'w2': 14})
 ```
 
 Enable case-insensitive player names to treat "shusaku" and "ShUsAkU" as the same entity:
 
 ```python
-whr = whole_history_rating.Base({'uncased': True})
+whr = WHR({'uncased': True})
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,24 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["whr"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+filterwarnings = ["error"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "W"]
+# Line length is governed by the formatter; long docstrings/strings are left as-is.
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.11"
+files = ["whr"]
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "whole-history-rating"
-version = "0.1.0"
+version = "2.0.0"
 description = "Python implementation of Rémi Coulom's Whole-History Rating (WHR) algorithm."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/whr_test.py
+++ b/tests/whr_test.py
@@ -1,13 +1,11 @@
 import copy
-import sys
-import os
 import pickle
+import sys
 import warnings
+
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-from whr import whole_history_rating
-from whr import utils
+from whr import utils, whole_history_rating
 
 
 def setup_game_with_elo(white_elo, black_elo, handicap):
@@ -143,7 +141,7 @@ def test_creating_games():
     assert list(whr.players.keys()) == ["shusai", "shusaku"]
 
 
-def test_loading_several_games_at_once(capsys):
+def test_loading_several_games_at_once(capsys, tmp_path):
     whr = whole_history_rating.WHR()
     # test loading several games at once
     test_games = [
@@ -174,7 +172,7 @@ def test_loading_several_games_at_once(capsys):
     assert capsys.readouterr().out == ""
     assert "nobody2" not in whr.players
     # test getting log likelihood of base
-    assert whr.log_likelihood() == 0.7431542354571272
+    assert whr.log_likelihood() == pytest.approx(0.7431542354571272)
     # test printing ordered ratings
     whr.print_ordered_ratings()
     display = "nobody => [-112.37545390067574]\nshusaku => [25.552142942931102, 24.669738398550702, 24.49953062693439]\nshusai => [84.74972643795506, 86.17200033461006, 86.88207745833284]\n"
@@ -192,27 +190,27 @@ def test_loading_several_games_at_once(capsys):
         [84.74972643795506, 86.17200033461006, 86.88207745833284],
     ]
     # test getting ordered ratings, only current elo with compact form
-    assert whr.get_ordered_ratings(compact=True, current=True) == [
-        -112.37545390067574,
-        24.49953062693439,
-        86.88207745833284,
-    ]
+    assert whr.get_ordered_ratings(compact=True, current=True) == pytest.approx(
+        [-112.37545390067574, 24.49953062693439, 86.88207745833284]
+    )
     # test saving base
-    whole_history_rating.WHR.save_base(whr, "test_whr.pkl")
+    path = str(tmp_path / "state.pkl")
+    whole_history_rating.WHR.save_base(whr, path)
     # test loading base
-    whr2 = whole_history_rating.WHR.load_base("test_whr.pkl")
+    whr2 = whole_history_rating.WHR.load_base(path)
     # test inspecting the first game
     whr_games = [str(x) for x in whr.games]
     whr2_games = [str(x) for x in whr2.games]
     assert whr_games == whr2_games
 
 
-def test_save_and_load():
+def test_save_and_load(tmp_path):
     whr = whole_history_rating.WHR(
         config={"w2": 1000, "uncased": True, "debug": True, "extra_parameter": "hello"}
     )
-    whole_history_rating.WHR.save_base(whr, "test_whr.pkl")
-    whr2 = whole_history_rating.WHR.load_base("test_whr.pkl")
+    path = str(tmp_path / "state.pkl")
+    whole_history_rating.WHR.save_base(whr, path)
+    whr2 = whole_history_rating.WHR.load_base(path)
     assert whr.config == whr2.config
 
 
@@ -222,7 +220,7 @@ def test_save_and_load_large_history_does_not_hit_recursion_limit(tmp_path):
     # so serialization must not rely on recursively walking it.
     whr = whole_history_rating.WHR()
     for i in range(2000):
-        whr.create_game(f"p{i}", f"p{i+1}", "B", i + 1, 0)
+        whr.create_game(f"p{i}", f"p{i + 1}", "B", i + 1, 0)
     whr.iterate(10)
 
     path = str(tmp_path / "large.pkl")

--- a/uv.lock
+++ b/uv.lock
@@ -368,7 +368,7 @@ wheels = [
 
 [[package]]
 name = "whole-history-rating"
-version = "0.1.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },

--- a/whr/player.py
+++ b/whr/player.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+import bisect
 import math
 import sys
-import bisect
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-from whr.utils import UnstableRatingException
-from whr import playerday as PD
 from whr import game as G
+from whr import playerday as PD
+from whr.utils import UnstableRatingException
 
 
 class Player:
@@ -32,7 +32,7 @@ class Player:
         sigma2 = self.compute_sigma2()
         n = len(self.days)
         for i in range(n):
-            prior = 0
+            prior = 0.0
             if i < (n - 1):
                 rd = self.days[i].r - self.days[i + 1].r
                 prior += (1 / (math.sqrt(2 * math.pi * sigma2[i]))) * math.exp(
@@ -75,7 +75,7 @@ class Player:
         diagonal = np.zeros((n,))
         sub_diagonal = np.zeros((n - 1,))
         for row in range(n):
-            prior = 0
+            prior = 0.0
             if row < (n - 1):
                 prior += -1 / sigma2[row]
             if row > 0:
@@ -101,7 +101,7 @@ class Player:
         g = []
         n = len(days)
         for idx, day in enumerate(days):
-            prior = 0
+            prior = 0.0
             if idx < (n - 1):
                 prior += -(r[idx] - r[idx + 1]) / sigma2[idx]
             if idx > 0:
@@ -127,7 +127,7 @@ class Player:
             list[float]: A list of variance values between consecutive rating days.
         """
         sigma2 = []
-        for d1, d2 in zip(self.days, self.days[1:]):
+        for d1, d2 in zip(self.days, self.days[1:], strict=False):
             sigma2.append(abs(d2.day - d1.day) * self.w2)
         return sigma2
 
@@ -164,7 +164,7 @@ class Player:
         for i in range(n - 2, -1, -1):
             x[i] = (y[i] - b[i] * x[i + 1]) / d[i]
 
-        new_r = [ri - xi for ri, xi in zip(r, x)]
+        new_r = [ri - xi for ri, xi in zip(r, x, strict=True)]
 
         for candidate in new_r:
             if candidate > 650:

--- a/whr/playerday.py
+++ b/whr/playerday.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import math
 
-from whr import player as P
 from whr import game as G
+from whr import player as P
 
 
 class PlayerDay:
@@ -11,10 +11,10 @@ class PlayerDay:
         self.day = day
         self.player = player
         self.is_first_day = False
-        self.won_games = []
-        self.lost_games = []
-        self._won_game_terms = None
-        self._lost_game_terms = None
+        self.won_games: list[G.Game] = []
+        self.lost_games: list[G.Game] = []
+        self._won_game_terms: list[list[float]] | None = None
+        self._lost_game_terms: list[list[float]] | None = None
         self.uncertainty: float = -1
         # natural-rating (log-gamma); overwritten by set_gamma / the elo setter
         self.r: float = 0.0
@@ -121,10 +121,10 @@ class PlayerDay:
             float: The log likelihood.
         """
         tally = 0.0
-        for a, b, c, d in self.won_game_terms():
+        for a, _b, c, d in self.won_game_terms():
             tally += math.log(a * self.gamma())
             tally -= math.log(c * self.gamma() + d)
-        for a, b, c, d in self.lost_game_terms():
+        for _a, b, c, d in self.lost_game_terms():
             tally += math.log(b)
             tally -= math.log(c * self.gamma() + d)
         return tally

--- a/whr/utils.py
+++ b/whr/utils.py
@@ -22,7 +22,7 @@ def test_stability(
     """
     v1_flattened = [x for y in v1 for x in y]
     v2_flattened = [x for y in v2 for x in y]
-    for x1, x2 in zip(v1_flattened, v2_flattened):
+    for x1, x2 in zip(v1_flattened, v2_flattened, strict=False):
         if abs(x2 - x1) > precision:
             return False
     return True

--- a/whr/whole_history_rating.py
+++ b/whr/whole_history_rating.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import time
 import ast
 import pickle
+import time
 import warnings
-from typing import Any
+from typing import Any, cast
 
-from whr.utils import test_stability
-from whr.player import Player
 from whr.game import Game
+from whr.player import Player
+from whr.utils import test_stability
 
 
 class WHR:
@@ -19,8 +19,8 @@ class WHR:
         self.config.setdefault("debug", False)
         self.config.setdefault("w2", 300.0)
         self.config.setdefault("uncased", False)
-        self.games = []
-        self.players = {}
+        self.games: list[Game] = []
+        self.players: dict[str, Player] = {}
 
     def print_ordered_ratings(self, current: bool = False) -> None:
         """Displays all ratings for each player (for each of their playing days), ordered.
@@ -39,7 +39,12 @@ class WHR:
 
     def get_ordered_ratings(
         self, current: bool = False, compact: bool = False
-    ) -> list[list[float]]:
+    ) -> (
+        list[float]
+        | list[tuple[str, float]]
+        | list[list[float]]
+        | list[tuple[str, list[float]]]
+    ):
         """Retrieves all ratings for each player (for each of their playing days), ordered.
 
         Args:
@@ -47,9 +52,9 @@ class WHR:
             compact (bool, optional): If True, returns only a list of elo ratings. If False, includes the player's name before their elo ratings.
 
         Returns:
-            list[list[float]]: A list containing the elo ratings for each player and each of their playing days.
+            The elo ratings for each player, ordered. The exact shape depends on ``current`` and ``compact``: a plain list of elos, a list of ``(name, elo)`` tuples, a list of per-day elo lists, or a list of ``(name, per-day elos)`` tuples.
         """
-        result = []
+        result: list[Any] = []
         players = [x for x in self.players.values() if len(x.days) > 0]
         players.sort(key=lambda x: x.days[-1].gamma())
         for p in players:
@@ -210,12 +215,13 @@ class WHR:
             tuple[int, bool]: The number of iterations performed and a boolean indicating whether stability was reached.
         """
         start = time.time()
-        a = None
+        a: list[list[float]] | None = None
         i = 0
         while True:
             self.iterate(batch_size)
             i += batch_size
-            b = self.get_ordered_ratings(compact=True)
+            # compact=True yields the list[list[float]] shape test_stability needs.
+            b = cast("list[list[float]]", self.get_ordered_ratings(compact=True))
             if a is not None and test_stability(a, b, precision):
                 return i, True
             if time_limit is not None and time.time() - start > time_limit:
@@ -247,10 +253,10 @@ class WHR:
         # Pure query: look players up without creating persistent entries.
         player1 = self._existing_player(name1)
         player2 = self._existing_player(name2)
-        bpd_gamma = 1
-        bpd_elo = 0
-        wpd_gamma = 1
-        wpd_elo = 0
+        bpd_gamma = 1.0
+        bpd_elo = 0.0
+        wpd_gamma = 1.0
+        wpd_elo = 0.0
         if player1 is not None and len(player1.days) > 0:
             bpd = player1.days[-1]
             bpd_gamma = bpd.gamma()
@@ -301,19 +307,21 @@ class WHR:
                     except (ValueError, SyntaxError):
                         raise ValueError(
                             f"Invalid handicap or extra value in: '{line}'"
-                        )
+                        ) from None
 
             if len(rest) == 2:
                 try:
                     handicap = int(rest[0])
                 except ValueError:
-                    raise ValueError(f"Invalid handicap value in: '{line}'")
+                    raise ValueError(f"Invalid handicap value in: '{line}'") from None
                 try:
                     extras = ast.literal_eval(rest[1])
                     if not isinstance(extras, dict):
                         raise ValueError()
                 except (ValueError, SyntaxError):
-                    raise ValueError(f"Invalid extras dictionary in: '{line}'")
+                    raise ValueError(
+                        f"Invalid extras dictionary in: '{line}'"
+                    ) from None
 
             if self.config["uncased"]:
                 black, white = black.lower(), white.lower()
@@ -354,9 +362,7 @@ class WHR:
             pickle.dumps(config)
         except Exception:
             config = {
-                k: v
-                for k, v in self.config.items()
-                if k in ["w2", "debug", "uncased"]
+                k: v for k, v in self.config.items() if k in ["w2", "debug", "uncased"]
             }
             warnings.warn(
                 "Some elements in config cannot be pickled; only 'w2', 'debug' "


### PR DESCRIPTION
Part of the code-health review (3 of 3 remaining PRs, based on `master`).

- Configure ruff (lint + format), mypy and pytest; add a GitHub Actions matrix (Python 3.11/3.12/3.13) running lint, types and tests — which also validates the supported-version floor.
- Fix everything ruff/mypy flagged (import order, `zip(strict=)`, unused loop vars, `raise ... from None`, missing annotations, a wrong `get_ordered_ratings` return type).
- Tests: write pickle files under `tmp_path`, drop the `sys.path` hack, use `pytest.approx` for brittle float assertions.
- README updated to `WHR` (+ `Base` deprecation note), corrected ratings shape and side-effect-free prediction example, documented save/load.
- Bump version to **2.0.0** and add a CHANGELOG (breaking changes over the published 1.6.2).

After this lands, `master` is ready to tag v2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)